### PR TITLE
「AWS CloudTrailのログをAmazon Elasticsearch Serviceへ転送して可視化してみた」の土台部分をterraformで作る

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.tfstate
 *.py
 *.zip
+*.pub

--- a/cloudtrail_to_elasticsearch/cloudtrail.tf
+++ b/cloudtrail_to_elasticsearch/cloudtrail.tf
@@ -1,0 +1,11 @@
+###
+#
+# CloudTrail
+#
+resource "aws_cloudtrail" "all-region" {
+  name                          = "cloudtrail-all-region"
+  s3_bucket_name                = "${aws_s3_bucket.log.id}"
+  enable_log_file_validation    = true
+  include_global_service_events = true
+  is_multi_region_trail         = true
+}

--- a/cloudtrail_to_elasticsearch/cloudtrail.tf
+++ b/cloudtrail_to_elasticsearch/cloudtrail.tf
@@ -10,8 +10,5 @@ resource "aws_cloudtrail" "all-region" {
   is_multi_region_trail         = true
 
   cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.cloudtrail.arn}"
-
-  # AWSコンソールから実施するとIAMロールの紐付けと別に、独自のポリシー(oneClick_Cloudtrail...)の紐付けを要求される
-  # 独自のポリシーの操作がterraformから難しいので、AWSコンソールから作成する
-  # cloud_watch_logs_role_arn  = "${aws_iam_role.cloudtrail.arn}"
+  cloud_watch_logs_role_arn  = "${aws_iam_role.cloudtrail.arn}"
 }

--- a/cloudtrail_to_elasticsearch/cloudtrail.tf
+++ b/cloudtrail_to_elasticsearch/cloudtrail.tf
@@ -8,4 +8,10 @@ resource "aws_cloudtrail" "all-region" {
   enable_log_file_validation    = true
   include_global_service_events = true
   is_multi_region_trail         = true
+
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.cloudtrail.arn}"
+
+  # AWSコンソールから実施するとIAMロールの紐付けと別に、独自のポリシー(oneClick_Cloudtrail...)の紐付けを要求される
+  # 独自のポリシーの操作がterraformから難しいので、AWSコンソールから作成する
+  # cloud_watch_logs_role_arn  = "${aws_iam_role.cloudtrail.arn}"
 }

--- a/cloudtrail_to_elasticsearch/cloudwatch_logs.tf
+++ b/cloudtrail_to_elasticsearch/cloudwatch_logs.tf
@@ -1,0 +1,11 @@
+###
+#
+# CloudWatch Logs Group
+#
+resource "aws_cloudwatch_log_group" "cloudtrail" {
+  name = "CloudTrail/SampleLogGroup"
+
+  tags {
+    Name = "CloudTrail/SampleLogGroup"
+  }
+}

--- a/cloudtrail_to_elasticsearch/config.tf
+++ b/cloudtrail_to_elasticsearch/config.tf
@@ -1,0 +1,11 @@
+###
+#
+# Remote State
+#
+terraform {
+  backend "s3" {
+    bucket = "anorlondo448-terraform"
+    key    = "cloudtrail_to_elasticsearch/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/cloudtrail_to_elasticsearch/ec2.tf
+++ b/cloudtrail_to_elasticsearch/ec2.tf
@@ -33,7 +33,7 @@ data "aws_ami" "amazon_linux" {
 }
 
 resource "aws_instance" "bastion" {
-  ami                         = "${data.aws_ami.amazon_linux.id}"
+  ami                         = "ami-c2680fa4"                       // Amazon Linux 2
   instance_type               = "${var.instance-type}"
   vpc_security_group_ids      = ["${aws_security_group.bastion.id}"]
   subnet_id                   = "${aws_subnet.public.id}"

--- a/cloudtrail_to_elasticsearch/ec2.tf
+++ b/cloudtrail_to_elasticsearch/ec2.tf
@@ -1,0 +1,51 @@
+###
+#
+# Ec2
+#
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "block-device-mapping.volume-type"
+    values = ["gp2"]
+  }
+}
+
+resource "aws_instance" "bastion" {
+  ami                         = "${data.aws_ami.amazon_linux.id}"
+  instance_type               = "${var.instance-type}"
+  vpc_security_group_ids      = ["${aws_security_group.bastion.id}"]
+  subnet_id                   = "${aws_subnet.public.id}"
+  key_name                    = "${aws_key_pair.bastion.key_name}"
+  associate_public_ip_address = true
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 8
+  }
+
+  tags {
+    Name = "bastion-for-kibana"
+  }
+}

--- a/cloudtrail_to_elasticsearch/elasticsearch.tf
+++ b/cloudtrail_to_elasticsearch/elasticsearch.tf
@@ -20,6 +20,12 @@ resource "aws_elasticsearch_domain" "cloudtrail" {
     ]
   }
 
+  ebs_options {
+    ebs_enabled = "true"
+    volume_type = "gp2"
+    volume_size = "10"
+  }
+
   advanced_options {
     "rest.action.multi.allow_explicit_index" = "true"
   }

--- a/cloudtrail_to_elasticsearch/elasticsearch.tf
+++ b/cloudtrail_to_elasticsearch/elasticsearch.tf
@@ -1,0 +1,50 @@
+###
+#
+# Elasticsearch
+#
+resource "aws_elasticsearch_domain" "cloudtrail" {
+  domain_name           = "cloudtrail"
+  elasticsearch_version = "6.2"
+
+  cluster_config {
+    instance_type = "t2.small.elasticsearch"
+  }
+
+  vpc_options {
+    subnet_ids = [
+      "${aws_subnet.private.id}",
+    ]
+
+    security_group_ids = [
+      "${aws_security_group.elasticsearch.id}",
+    ]
+  }
+
+  advanced_options {
+    "rest.action.multi.allow_explicit_index" = "true"
+  }
+
+  access_policies = <<CONFIG
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "es:*",
+      "Resource": "arn:aws:es:ap-northeast-1:${var.account-id}:domain/cloudtrail/*"
+    }
+  ]
+}
+CONFIG
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  tags {
+    Domain = "cloudtrail"
+  }
+}

--- a/cloudtrail_to_elasticsearch/iam_policy.tf
+++ b/cloudtrail_to_elasticsearch/iam_policy.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "cloudtrail" {
     ]
 
     resources = [
-      "arn:aws:logs:ap-northeast-1:${var.account-id}:log-group:CloudTrail/DefaultLogGroup:log-stream:${var.account-id}_CloudTrail_ap-northeast-1*",
+      "${aws_cloudwatch_log_group.cloudtrail.arn}",
     ]
   }
 
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "cloudtrail" {
     ]
 
     resources = [
-      "arn:aws:logs:ap-northeast-1:${var.account-id}:log-group:CloudTrail/DefaultLogGroup:log-stream:${var.account-id}_CloudTrail_ap-northeast-1*",
+      "${aws_cloudwatch_log_group.cloudtrail.arn}",
     ]
   }
 }

--- a/cloudtrail_to_elasticsearch/iam_policy.tf
+++ b/cloudtrail_to_elasticsearch/iam_policy.tf
@@ -1,0 +1,36 @@
+###
+#
+# IAM Policy
+#
+data "aws_iam_policy_document" "cloudtrail" {
+  statement {
+    sid    = "AWSCloudTrailCreateLogStream20141101"
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogStream",
+    ]
+
+    resources = [
+      "arn:aws:logs:ap-northeast-1:${var.account-id}:log-group:CloudTrail/DefaultLogGroup:log-stream:${var.account-id}_CloudTrail_ap-northeast-1*",
+    ]
+  }
+
+  statement {
+    sid    = "AWSCloudTrailPutLogEvents20141101"
+    effect = "Allow"
+
+    actions = [
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "arn:aws:logs:ap-northeast-1:${var.account-id}:log-group:CloudTrail/DefaultLogGroup:log-stream:${var.account-id}_CloudTrail_ap-northeast-1*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "cloudtrail" {
+  name   = "cloudtrail"
+  policy = "${data.aws_iam_policy_document.cloudtrail.json}"
+}

--- a/cloudtrail_to_elasticsearch/iam_policy.tf
+++ b/cloudtrail_to_elasticsearch/iam_policy.tf
@@ -34,3 +34,39 @@ resource "aws_iam_policy" "cloudtrail" {
   name   = "cloudtrail"
   policy = "${data.aws_iam_policy_document.cloudtrail.json}"
 }
+
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "es:ESHttpPost",
+    ]
+
+    resources = [
+      "arn:aws:es:*:*:*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lambda" {
+  name   = "lambda"
+  policy = "${data.aws_iam_policy_document.lambda.json}"
+}

--- a/cloudtrail_to_elasticsearch/iam_role.tf
+++ b/cloudtrail_to_elasticsearch/iam_role.tf
@@ -25,3 +25,27 @@ resource "aws_iam_role_policy_attachment" "cloudtrail" {
   role       = "${aws_iam_role.cloudtrail.name}"
   policy_arn = "${aws_iam_policy.cloudtrail.arn}"
 }
+
+resource "aws_iam_role" "lambda" {
+  name = "lambda_elasticsearch_execution"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda" {
+  role       = "${aws_iam_role.lambda.name}"
+  policy_arn = "${aws_iam_policy.lambda.arn}"
+}

--- a/cloudtrail_to_elasticsearch/iam_role.tf
+++ b/cloudtrail_to_elasticsearch/iam_role.tf
@@ -1,0 +1,27 @@
+###
+#
+# IAM Role
+#
+resource "aws_iam_role" "cloudtrail" {
+  name = "CloudTrail_CloudWatchLogs_Role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "cloudtrail" {
+  role       = "${aws_iam_role.cloudtrail.name}"
+  policy_arn = "${aws_iam_policy.cloudtrail.arn}"
+}

--- a/cloudtrail_to_elasticsearch/internet_gateway.tf
+++ b/cloudtrail_to_elasticsearch/internet_gateway.tf
@@ -1,0 +1,11 @@
+###
+#
+# Internet Gateway
+#
+resource "aws_internet_gateway" "elasticsearch" {
+  vpc_id = "${aws_vpc.elasticsearch.id}"
+
+  tags {
+    Name = "elasticsearch"
+  }
+}

--- a/cloudtrail_to_elasticsearch/key_pair.tf
+++ b/cloudtrail_to_elasticsearch/key_pair.tf
@@ -1,0 +1,8 @@
+###
+#
+# Key Pair
+#
+resource "aws_key_pair" "bastion" {
+  key_name   = "bastion-for-kibana"
+  public_key = "${file("bastion.pub")}"
+}

--- a/cloudtrail_to_elasticsearch/route_table.tf
+++ b/cloudtrail_to_elasticsearch/route_table.tf
@@ -1,0 +1,21 @@
+###
+#
+# Route Table
+#
+resource "aws_route_table" "main" {
+  vpc_id = "${aws_vpc.elasticsearch.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.elasticsearch.id}"
+  }
+}
+
+###
+#
+# Route Table Assosiation
+#
+resource "aws_route_table_association" "main" {
+  subnet_id      = "${aws_subnet.public.id}"
+  route_table_id = "${aws_route_table.main.id}"
+}

--- a/cloudtrail_to_elasticsearch/s3.tf
+++ b/cloudtrail_to_elasticsearch/s3.tf
@@ -1,0 +1,39 @@
+###
+#
+# S3
+#
+resource "aws_s3_bucket" "log" {
+  bucket        = "${var.s3-bucket}"
+  force_destroy = true
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSCloudTrailAclCheck",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:GetBucketAcl",
+            "Resource": "arn:aws:s3:::${var.s3-bucket}"
+        },
+        {
+            "Sid": "AWSCloudTrailWrite",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::${var.s3-bucket}/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        }
+    ]
+}
+POLICY
+}

--- a/cloudtrail_to_elasticsearch/security_group.tf
+++ b/cloudtrail_to_elasticsearch/security_group.tf
@@ -31,3 +31,23 @@ resource "aws_security_group" "bastion" {
     Name = "bastion"
   }
 }
+
+resource "aws_security_group" "lambda" {
+  name        = "lambda"
+  description = "lambda security group"
+  vpc_id      = "${aws_vpc.elasticsearch.id}"
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  tags {
+    Name = "lambda"
+  }
+}

--- a/cloudtrail_to_elasticsearch/security_group.tf
+++ b/cloudtrail_to_elasticsearch/security_group.tf
@@ -51,3 +51,34 @@ resource "aws_security_group" "lambda" {
     Name = "lambda"
   }
 }
+
+resource "aws_security_group" "elasticsearch" {
+  name        = "elasticsearch"
+  description = "elasticsearch security group"
+  vpc_id      = "${aws_vpc.elasticsearch.id}"
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    security_groups = [
+      "${aws_security_group.bastion.id}",
+      "${aws_security_group.lambda.id}",
+    ]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  tags {
+    Name = "elasticsearch"
+  }
+}

--- a/cloudtrail_to_elasticsearch/security_group.tf
+++ b/cloudtrail_to_elasticsearch/security_group.tf
@@ -1,0 +1,33 @@
+###
+#
+# Security Group
+#
+resource "aws_security_group" "bastion" {
+  name        = "bastion"
+  description = "bastion security group"
+  vpc_id      = "${aws_vpc.elasticsearch.id}"
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  tags {
+    Name = "bastion"
+  }
+}

--- a/cloudtrail_to_elasticsearch/security_group.tf
+++ b/cloudtrail_to_elasticsearch/security_group.tf
@@ -17,6 +17,26 @@ resource "aws_security_group" "bastion" {
     ]
   }
 
+  ingress {
+    from_port = 500
+    to_port   = 500
+    protocol  = "udp"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  ingress {
+    from_port = 4500
+    to_port   = 4500
+    protocol  = "udp"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
   egress {
     from_port = 0
     to_port   = 0

--- a/cloudtrail_to_elasticsearch/subnet.tf
+++ b/cloudtrail_to_elasticsearch/subnet.tf
@@ -18,6 +18,16 @@ resource "aws_subnet" "private" {
   availability_zone = "ap-northeast-1d"
 
   tags {
-    Name = "private-subnet"
+    Name = "private-subnet-1d"
+  }
+}
+
+resource "aws_subnet" "private2" {
+  vpc_id            = "${aws_vpc.elasticsearch.id}"
+  cidr_block        = "${var.cidr-private-subnet-1c}"
+  availability_zone = "ap-northeast-1c"
+
+  tags {
+    Name = "private-subnet-1c"
   }
 }

--- a/cloudtrail_to_elasticsearch/subnet.tf
+++ b/cloudtrail_to_elasticsearch/subnet.tf
@@ -2,7 +2,7 @@
 #
 # Subnet
 #
-resource aws_subnet "public" {
+resource "aws_subnet" "public" {
   vpc_id            = "${aws_vpc.elasticsearch.id}"
   cidr_block        = "${var.cidr-public-subnet}"
   availability_zone = "ap-northeast-1a"
@@ -12,7 +12,7 @@ resource aws_subnet "public" {
   }
 }
 
-resource aws_subnet "private" {
+resource "aws_subnet" "private" {
   vpc_id            = "${aws_vpc.elasticsearch.id}"
   cidr_block        = "${var.cidr-private-subnet}"
   availability_zone = "ap-northeast-1d"

--- a/cloudtrail_to_elasticsearch/subnet.tf
+++ b/cloudtrail_to_elasticsearch/subnet.tf
@@ -1,0 +1,23 @@
+###
+#
+# Subnet
+#
+resource aws_subnet "public" {
+  vpc_id            = "${aws_vpc.elasticsearch.id}"
+  cidr_block        = "${var.cidr-public-subnet}"
+  availability_zone = "ap-northeast-1a"
+
+  tags {
+    Name = "public-subnet"
+  }
+}
+
+resource aws_subnet "private" {
+  vpc_id            = "${aws_vpc.elasticsearch.id}"
+  cidr_block        = "${var.cidr-private-subnet}"
+  availability_zone = "ap-northeast-1d"
+
+  tags {
+    Name = "private-subnet"
+  }
+}

--- a/cloudtrail_to_elasticsearch/variables.tf
+++ b/cloudtrail_to_elasticsearch/variables.tf
@@ -34,3 +34,9 @@ variable "cidr-private-subnet" {
   type    = "string"
   default = "10.2.20.0/24"
 }
+
+## S3 bucket for cloudtrail log
+variable "s3-bucket" {
+  type    = "string"
+  default = "cloudtrail-all-region-anorlondo"
+}

--- a/cloudtrail_to_elasticsearch/variables.tf
+++ b/cloudtrail_to_elasticsearch/variables.tf
@@ -13,8 +13,24 @@ variable "region" {
   default = "ap-northeast-1"
 }
 
+###
+#
+# Network
+#
 ## vpc のCIDR
 variable "cidr-vpc" {
   type    = "string"
   default = "10.2.0.0/16"
+}
+
+## public subnet のCIDR(bastion用)
+variable "cidr-public-subnet" {
+  type    = "string"
+  default = "10.2.10.0/24"
+}
+
+## private subnet のCIDR(Elasticsearch,kibana,lambda用)
+variable "cidr-private-subnet" {
+  type    = "string"
+  default = "10.2.20.0/24"
 }

--- a/cloudtrail_to_elasticsearch/variables.tf
+++ b/cloudtrail_to_elasticsearch/variables.tf
@@ -41,6 +41,11 @@ variable "cidr-private-subnet" {
   default = "10.2.20.0/24"
 }
 
+variable "cidr-private-subnet-1c" {
+  type    = "string"
+  default = "10.2.30.0/24"
+}
+
 ## S3 bucket for cloudtrail log
 variable "s3-bucket" {
   type    = "string"

--- a/cloudtrail_to_elasticsearch/variables.tf
+++ b/cloudtrail_to_elasticsearch/variables.tf
@@ -13,6 +13,12 @@ variable "region" {
   default = "ap-northeast-1"
 }
 
+## AWSアカウントID
+variable "account-id" {
+  type    = "string"
+  default = "793428494912"
+}
+
 ###
 #
 # Network

--- a/cloudtrail_to_elasticsearch/variables.tf
+++ b/cloudtrail_to_elasticsearch/variables.tf
@@ -46,3 +46,12 @@ variable "s3-bucket" {
   type    = "string"
   default = "cloudtrail-all-region-anorlondo"
 }
+
+###
+#
+# EC2
+#
+variable "instance-type" {
+  type    = "string"
+  default = "t2.micro"
+}

--- a/cloudtrail_to_elasticsearch/variables.tf
+++ b/cloudtrail_to_elasticsearch/variables.tf
@@ -1,0 +1,14 @@
+###
+#
+# Common
+#
+## 対象となるプロバイダ(AWS,GCP,etc)を指定します
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+## AWS上で使用するリージョンを指定します
+variable "region" {
+  type    = "string"
+  default = "ap-northeast-1"
+}

--- a/cloudtrail_to_elasticsearch/variables.tf
+++ b/cloudtrail_to_elasticsearch/variables.tf
@@ -12,3 +12,9 @@ variable "region" {
   type    = "string"
   default = "ap-northeast-1"
 }
+
+## vpc のCIDR
+variable "cidr-vpc" {
+  type    = "string"
+  default = "10.2.0.0/16"
+}

--- a/cloudtrail_to_elasticsearch/vpc.tf
+++ b/cloudtrail_to_elasticsearch/vpc.tf
@@ -3,7 +3,7 @@
 # VPC
 #
 resource "aws_vpc" "elasticsearch" {
-  cidr_block = "10.2.0.0/16"
+  cidr_block = "${var.cidr-vpc}"
 
   tags {
     Name = "elasticsearch"

--- a/cloudtrail_to_elasticsearch/vpc.tf
+++ b/cloudtrail_to_elasticsearch/vpc.tf
@@ -1,0 +1,11 @@
+###
+#
+# VPC
+#
+resource "aws_vpc" "elasticsearch" {
+  cidr_block = "10.2.0.0/16"
+
+  tags {
+    Name = "elasticsearch"
+  }
+}


### PR DESCRIPTION
 - [AWS CloudTrailのログをAmazon Elasticsearch Serviceへ転送して可視化してみた](http://kakakakakku.hatenablog.com/entry/2018/04/02/213042)
- 細切れの時間でもやれるように、terraformでやったところまで再現可能にしておく。